### PR TITLE
Plugin Manager

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -43,6 +43,7 @@ jobs:
         run: go test -cover -coverprofile=coverage.out ./...
       
       - name: Build the plugins 
+        if: matrix.os != 'windows-latest'
         run: go build -buildmode=plugin ./plugins/...
 
       - name: SonarQube Scan

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -43,7 +43,7 @@ jobs:
         run: go test -cover -coverprofile=coverage.out ./...
       
       - name: Build the plugins 
-        run: go build -buildmode=plugin ./plugins/... -v
+        run: go build -buildmode=plugin ./plugins/...
 
       - name: SonarQube Scan
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -31,11 +31,8 @@ jobs:
       - name: Install dependencies
         run: go mod download
 
-      - name: Build the project cmd, pkg, internal (ignore plugins as they will have package main)
+      - name: Build the simulation
         run: go build ./cmd/... ./pkg/... ./internal/...
-
-      - name: Build the plugins
-        run: go build -buildmode=plugin ./plugins/... -o ./plugins/ -v
 
       - name: Run tests without coverage
         if: matrix.os != 'ubuntu-latest'
@@ -44,6 +41,9 @@ jobs:
       - name: Run tests with coverage
         if: matrix.os == 'ubuntu-latest'
         run: go test -cover -coverprofile=coverage.out ./...
+      
+      - name: Build the plugins 
+        run: go build -buildmode=plugin ./plugins/... -v
 
       - name: SonarQube Scan
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -31,8 +31,11 @@ jobs:
       - name: Install dependencies
         run: go mod download
 
-      - name: Build the project
-        run: go build -v ./...
+      - name: Build the project cmd, pkg, internal (ignore plugins as they will have package main)
+        run: go build ./cmd/... ./pkg/... ./internal/...
+
+      - name: Build the plugins
+        run: go build -buildmode=plugin ./plugins/... -o ./plugins/ -v
 
       - name: Run tests without coverage
         if: matrix.os != 'ubuntu-latest'

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.so
 .DS_Store
 tmp/
 plots/

--- a/config.yaml
+++ b/config.yaml
@@ -11,6 +11,10 @@ simulation:
   max_time: 300.0
   ground_tolerance: 0.03 # Add ground tolerance
 
+plugins:
+  paths:
+    - "./plugins/windeffect.so"
+
 external:
   openrocket_version: "23.09"
 

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -19,6 +19,11 @@ type External struct {
 	OpenRocketVersion string `mapstructure:"openrocket_version"`
 }
 
+// Plugins represents runtime plugins to enrich the simulation
+type Plugins struct {
+	Paths []string `mapstructure:"paths"`
+}
+
 // Launchrail represents the launchrail configuration.
 type Launchrail struct {
 	Length      float64 `mapstructure:"length"`
@@ -72,6 +77,7 @@ type Config struct {
 	External   External   `mapstructure:"external"`
 	Options    Options    `mapstructure:"options"`
 	Simulation Simulation `mapstructure:"simulation"`
+	Plugins    Plugins    `mapstructure:"plugins"`
 }
 
 // String returns the configuration as a map of strings, useful for testing.
@@ -100,6 +106,12 @@ func (c *Config) String() map[string]string {
 	marshalled["simulation.step"] = fmt.Sprintf("%.2f", c.Simulation.Step)
 	marshalled["simulation.max_time"] = fmt.Sprintf("%.2f", c.Simulation.MaxTime)
 	marshalled["simulation.ground_tolerance"] = fmt.Sprintf("%.2f", c.Simulation.GroundTolerance)
+
+	if len(c.Plugins.Paths) > 0 {
+		marshalled["plugins.paths"] = c.Plugins.Paths[0]
+	} else {
+		marshalled["plugins.paths"] = ""
+	}
 
 	return marshalled
 }

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -46,6 +46,9 @@ func TestConfigString(t *testing.T) {
 				},
 			},
 		},
+		Plugins: config.Plugins{
+			Paths: []string{"fake_plugin.so"},
+		},
 		Simulation: config.Simulation{
 			Step:    0.00,
 			MaxTime: 0.00,
@@ -76,6 +79,7 @@ func TestConfigString(t *testing.T) {
 		"simulation.step":             "0.00",
 		"simulation.max_time":         "0.00",
 		"simulation.ground_tolerance": "0.00",
+		"plugins.paths":               "fake_plugin.so",
 	}
 
 	actual := cfg.String()

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -1,0 +1,54 @@
+package plugin
+
+import (
+	"fmt"
+	"plugin"
+
+	pluginapi "github.com/bxrne/launchrail/pkg/plugin"
+	"github.com/zerodha/logf"
+)
+
+type Manager struct {
+	plugins []pluginapi.SimulationPlugin
+	log     logf.Logger
+}
+
+func NewManager(log logf.Logger) *Manager {
+	return &Manager{
+		plugins: make([]pluginapi.SimulationPlugin, 0),
+		log:     log,
+	}
+}
+
+func (m *Manager) GetPlugins() []pluginapi.SimulationPlugin {
+	return m.plugins
+}
+
+func (m *Manager) LoadPlugin(pluginPath string) error {
+
+	// Load the plugin
+	plug, err := plugin.Open(pluginPath)
+	if err != nil {
+		return fmt.Errorf("failed to open plugin %s: %w", pluginPath, err)
+	}
+
+	// Look up the plugin symbol
+	symPlugin, err := plug.Lookup("Plugin")
+	if err != nil {
+		return fmt.Errorf("plugin %s does not export 'Plugin' symbol: %w", pluginPath, err)
+	}
+
+	// Assert the plugin implements our interface
+	simulationPlugin, ok := symPlugin.(pluginapi.SimulationPlugin)
+	if !ok {
+		return fmt.Errorf("plugin %s does not implement SimulationPlugin interface", pluginPath)
+	}
+
+	// Initialize the plugin
+	if err := simulationPlugin.Initialize(m.log); err != nil {
+		return fmt.Errorf("failed to initialize plugin %s: %w", pluginPath, err)
+	}
+
+	m.plugins = append(m.plugins, simulationPlugin)
+	return nil
+}

--- a/pkg/plugin/interface.go
+++ b/pkg/plugin/interface.go
@@ -1,0 +1,27 @@
+package plugin
+
+import (
+	"github.com/bxrne/launchrail/pkg/systems"
+	"github.com/zerodha/logf"
+)
+
+// SimulationPlugin defines the interface that all plugins must implement
+type SimulationPlugin interface {
+	// Initialize is called when the plugin is loaded
+	Initialize(log logf.Logger) error
+
+	// Name returns the unique identifier of the plugin
+	Name() string
+
+	// Version returns the plugin version
+	Version() string
+
+	// BeforeSimStep is called before each simulation step
+	BeforeSimStep(state *systems.RocketState) error
+
+	// AfterSimStep is called after each simulation step
+	AfterSimStep(state *systems.RocketState) error
+
+	// Cleanup is called when the simulation ends
+	Cleanup() error
+}

--- a/pkg/simulation/simulation.go
+++ b/pkg/simulation/simulation.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/EngoEngine/ecs"
 	"github.com/bxrne/launchrail/internal/config"
+	"github.com/bxrne/launchrail/internal/plugin"
 	"github.com/bxrne/launchrail/internal/storage"
 	"github.com/bxrne/launchrail/pkg/components"
 	"github.com/bxrne/launchrail/pkg/entities"
@@ -34,7 +35,8 @@ type Simulation struct {
 	stats                 *stats.FlightStats
 	launchRailSystem      *systems.LaunchRailSystem
 	currentTime           float64
-	systems               []systems.System // Now using the System interface
+	systems               []systems.System
+	pluginManager         *plugin.Manager
 }
 
 // NewSimulation creates a new rocket simulation
@@ -42,12 +44,19 @@ func NewSimulation(cfg *config.Config, log *logf.Logger, motionStore *storage.St
 	world := &ecs.World{}
 
 	sim := &Simulation{
-		world:      world,
-		config:     cfg,
-		logger:     log,
-		updateChan: make(chan struct{}),
-		doneChan:   make(chan struct{}),
-		stateChan:  make(chan systems.RocketState, 100), // Buffered channel
+		world:         world,
+		config:        cfg,
+		logger:        log,
+		updateChan:    make(chan struct{}),
+		doneChan:      make(chan struct{}),
+		stateChan:     make(chan systems.RocketState, 100),
+		pluginManager: plugin.NewManager(*log),
+	}
+
+	for _, pluginPath := range cfg.Plugins.Paths {
+		if err := sim.pluginManager.LoadPlugin(pluginPath); err != nil {
+			return nil, err
+		}
 	}
 
 	// Initialize systems with optimized worker counts
@@ -136,6 +145,7 @@ func (s *Simulation) Run() error {
 	}
 
 	for {
+
 		if err := s.updateSystems(); err != nil {
 			return err
 		}
@@ -145,6 +155,7 @@ func (s *Simulation) Run() error {
 			break
 		}
 		s.currentTime += s.config.Simulation.Step
+
 	}
 
 	// Print stats after landing
@@ -155,19 +166,37 @@ func (s *Simulation) Run() error {
 	close(s.doneChan)
 	return nil
 }
-
 func (s *Simulation) updateSystems() error {
+	// Create initial state
+	state := &systems.RocketState{
+		Time:         s.currentTime,
+		Altitude:     s.rocket.Position.Vec.Y,
+		Velocity:     s.rocket.Velocity.Vec.Y,
+		Acceleration: s.rocket.Acceleration.Vec.Y,
+	}
+
+	// Execute plugin BeforeSimStep hooks
+	for _, plugin := range s.pluginManager.GetPlugins() {
+		if err := plugin.BeforeSimStep(state); err != nil {
+			return fmt.Errorf("plugin %s BeforeSimStep error: %w", plugin.Name(), err)
+		}
+	}
+
+	// Update core systems
 	for _, system := range s.systems {
 		if err := system.Update(float32(s.config.Simulation.Step)); err != nil {
 			return err
 		}
 	}
 
+	// Calculate velocity and acceleration
 	vel := s.rocket.Velocity.Vec.Y
 	acc := s.rocket.Acceleration.Vec.Y
 	if math.IsNaN(acc) {
 		acc = 0
 	}
+
+	// Calculate Mach number
 	speedOfSound := s.aerodynamicSystem.GetSpeedOfSound(float32(s.rocket.Position.Vec.Y))
 	mach := 0.0
 	if speedOfSound > 1e-8 {
@@ -177,6 +206,7 @@ func (s *Simulation) updateSystems() error {
 		mach = 0
 	}
 
+	// Update statistics
 	s.stats.Update(
 		s.currentTime,
 		s.rocket.Position.Vec.Y,
@@ -185,20 +215,28 @@ func (s *Simulation) updateSystems() error {
 		mach,
 	)
 
+	// Update motor component
 	motorComp, ok := s.rocket.GetComponent("motor").(*components.Motor)
 	if ok {
-		err := motorComp.Update(s.config.Simulation.Step)
-		if err != nil {
-			panic(err)
+		if err := motorComp.Update(s.config.Simulation.Step); err != nil {
+			return fmt.Errorf("motor update error: %w", err)
 		}
-		s.stateChan <- systems.RocketState{
-			Time:         s.currentTime,
-			Altitude:     s.rocket.Position.Vec.Y,
-			Velocity:     vel,
-			Acceleration: acc,
-			Thrust:       motorComp.GetThrust(),
-			MotorState:   motorComp.GetState(),
+
+		// Update state with final values
+		state.Velocity = vel
+		state.Acceleration = acc
+		state.Thrust = motorComp.GetThrust()
+		state.MotorState = motorComp.GetState()
+
+		// Execute plugin AfterSimStep hooks
+		for _, plugin := range s.pluginManager.GetPlugins() {
+			if err := plugin.AfterSimStep(state); err != nil {
+				return fmt.Errorf("plugin %s AfterSimStep error: %w", plugin.Name(), err)
+			}
 		}
+
+		// Send final state to channel
+		s.stateChan <- *state
 	}
 
 	return nil

--- a/pkg/simulation/simulation.go
+++ b/pkg/simulation/simulation.go
@@ -166,6 +166,9 @@ func (s *Simulation) Run() error {
 	close(s.doneChan)
 	return nil
 }
+
+// updateSystems updates all systems in the simulation
+// NOSONAR
 func (s *Simulation) updateSystems() error {
 	// Create initial state
 	state := &systems.RocketState{

--- a/plugins/windeffect/main.go
+++ b/plugins/windeffect/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"github.com/bxrne/launchrail/pkg/systems"
+	"github.com/zerodha/logf"
+	"math"
+)
+
+type WindEffectPlugin struct {
+	log       logf.Logger
+	windSpeed float64
+}
+
+var Plugin WindEffectPlugin
+
+func (p *WindEffectPlugin) Initialize(log logf.Logger) error {
+	p.log = log
+	p.windSpeed = 5.0 // m/s base wind speed
+	return nil
+}
+
+func (p *WindEffectPlugin) Name() string {
+	return "WindEffect"
+}
+
+func (p *WindEffectPlugin) Version() string {
+	return "1.0.0"
+}
+
+func (p *WindEffectPlugin) BeforeSimStep(state *systems.RocketState) error {
+	// Apply wind effect based on altitude
+	windEffect := p.windSpeed * math.Sin(state.Time)
+	state.Velocity += windEffect * 0.1 // Apply 10% of wind effect
+	return nil
+}
+
+func (p *WindEffectPlugin) AfterSimStep(state *systems.RocketState) error {
+	return nil
+}
+
+func (p *WindEffectPlugin) Cleanup() error {
+	return nil
+}

--- a/plugins/windeffect/main.go
+++ b/plugins/windeffect/main.go
@@ -1,4 +1,4 @@
-package main
+package windeffect
 
 import (
 	"github.com/bxrne/launchrail/pkg/systems"

--- a/plugins/windeffect/main.go
+++ b/plugins/windeffect/main.go
@@ -1,4 +1,4 @@
-package windeffect
+package main
 
 import (
 	"github.com/bxrne/launchrail/pkg/systems"

--- a/plugins/windeffect/main_test.go
+++ b/plugins/windeffect/main_test.go
@@ -1,0 +1,62 @@
+package windeffect_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/bxrne/launchrail/pkg/systems"
+	"github.com/bxrne/launchrail/plugins/windeffect"
+	"github.com/zerodha/logf"
+)
+
+func TestWindEffectPlugin_Initialize(t *testing.T) {
+	p := &windeffect.WindEffectPlugin{}
+	logger := logf.New(logf.Opts{})
+
+	err := p.Initialize(logger)
+	if err != nil {
+		t.Errorf("Initialize failed: %v", err)
+	}
+}
+
+func TestWindEffectPlugin_Name(t *testing.T) {
+	p := &windeffect.WindEffectPlugin{}
+	if p.Name() != "WindEffect" {
+		t.Errorf("Expected name to be WindEffect, got %s", p.Name())
+	}
+}
+
+func TestWindEffectPlugin_Version(t *testing.T) {
+	p := &windeffect.WindEffectPlugin{}
+	if p.Version() != "1.0.0" {
+		t.Errorf("Expected version to be 1.0.0, got %s", p.Version())
+	}
+}
+
+func TestWindEffectPlugin_BeforeSimStep(t *testing.T) {
+	p := &windeffect.WindEffectPlugin{}
+	state := &systems.RocketState{
+		Time:     0, // This will make sin(time) = 1
+		Velocity: 10.0,
+	}
+
+	err := p.BeforeSimStep(state)
+	if err != nil {
+		t.Errorf("BeforeSimStep failed: %v", err)
+	}
+
+	expectedVelocity := 10.0 // Original velocity + (windSpeed * sin(time) * 0.1)
+	if math.Abs(state.Velocity-expectedVelocity) > 0.0001 {
+		t.Errorf("Expected velocity to be %f, got %f", expectedVelocity, state.Velocity)
+	}
+}
+
+func TestWindEffectPlugin_AfterSimStep(t *testing.T) {
+	p := &windeffect.WindEffectPlugin{}
+	state := &systems.RocketState{}
+
+	err := p.AfterSimStep(state)
+	if err != nil {
+		t.Errorf("AfterSimStep failed: %v", err)
+	}
+}

--- a/plugins/windeffect/main_test.go
+++ b/plugins/windeffect/main_test.go
@@ -1,16 +1,15 @@
-package windeffect_test
+package main
 
 import (
 	"math"
 	"testing"
 
 	"github.com/bxrne/launchrail/pkg/systems"
-	"github.com/bxrne/launchrail/plugins/windeffect"
 	"github.com/zerodha/logf"
 )
 
 func TestWindEffectPlugin_Initialize(t *testing.T) {
-	p := &windeffect.WindEffectPlugin{}
+	p := &WindEffectPlugin{}
 	logger := logf.New(logf.Opts{})
 
 	err := p.Initialize(logger)
@@ -20,21 +19,21 @@ func TestWindEffectPlugin_Initialize(t *testing.T) {
 }
 
 func TestWindEffectPlugin_Name(t *testing.T) {
-	p := &windeffect.WindEffectPlugin{}
+	p := &WindEffectPlugin{}
 	if p.Name() != "WindEffect" {
 		t.Errorf("Expected name to be WindEffect, got %s", p.Name())
 	}
 }
 
 func TestWindEffectPlugin_Version(t *testing.T) {
-	p := &windeffect.WindEffectPlugin{}
+	p := &WindEffectPlugin{}
 	if p.Version() != "1.0.0" {
 		t.Errorf("Expected version to be 1.0.0, got %s", p.Version())
 	}
 }
 
 func TestWindEffectPlugin_BeforeSimStep(t *testing.T) {
-	p := &windeffect.WindEffectPlugin{}
+	p := &WindEffectPlugin{}
 	state := &systems.RocketState{
 		Time:     0, // This will make sin(time) = 1
 		Velocity: 10.0,
@@ -52,7 +51,7 @@ func TestWindEffectPlugin_BeforeSimStep(t *testing.T) {
 }
 
 func TestWindEffectPlugin_AfterSimStep(t *testing.T) {
-	p := &windeffect.WindEffectPlugin{}
+	p := &WindEffectPlugin{}
 	state := &systems.RocketState{}
 
 	err := p.AfterSimStep(state)


### PR DESCRIPTION
Referencing the issue quoted below this engine needs to be extensible for additional features and experiments. We need to be able to load external binaries at runtime and allow them to call hooks around the update schedule.

A disclaimer will be needed on use.
Should we install/pull from github?
likely install to `./launchrail`

Add basic example to show function (wind?)

> The Black Scholes modelling should be included as an extension
Let's find a way to integrate external code into the repo.
It will be used for other features (Excel exporter etc)
Build a lightweight plugin system