### PR TITLE
Potential fix for code scanning alert no. 7: Uncontrolled data used in path expression

### DIFF
--- a/cmd/server/handlers.go
+++ b/cmd/server/handlers.go
@@ -175,6 +175,12 @@ func (h *DataHandler) GetRecordData(c *gin.Context) {
 	hash := c.Param("hash")
 	dataType := c.Param("type")
 
+	// Validate the hash to ensure it is a single-component identifier
+	if strings.Contains(hash, "/") || strings.Contains(hash, "\\") || strings.Contains(hash, "..") {
+		renderTempl(c, pages.ErrorPage("Invalid record identifier"))
+		return
+	}
+
 	record, err := h.records.GetRecord(hash)
 	if err != nil {
 		renderTempl(c, pages.ErrorPage("Record not found"))

--- a/cmd/server/handlers.go
+++ b/cmd/server/handlers.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/a-h/templ"
 	"github.com/bxrne/launchrail/internal/config"
-	"github.com/bxrne/launchrail/internal/storage"
 	"github.com/bxrne/launchrail/internal/plot_transformer"
+	"github.com/bxrne/launchrail/internal/storage"
 	"github.com/bxrne/launchrail/templates/pages"
 	"github.com/gin-gonic/gin"
 )

--- a/internal/storage/records.go
+++ b/internal/storage/records.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"sync"
 	"time"
-	"runtime"
+
 	"github.com/bxrne/launchrail/internal/logger"
 )
 

--- a/internal/storage/records.go
+++ b/internal/storage/records.go
@@ -175,6 +175,11 @@ func (rm *RecordManager) ListRecords() ([]*Record, error) {
 
 // GetRecord retrieves an existing record by hash without creating a new one.
 func (rm *RecordManager) GetRecord(hash string) (*Record, error) {
+	// Validate the hash to ensure it is a single-component identifier
+	if strings.Contains(hash, "/") || strings.Contains(hash, "\\") || strings.Contains(hash, "..") {
+		return nil, fmt.Errorf("invalid record identifier")
+	}
+
 	rm.mu.RLock()
 	defer rm.mu.RUnlock()
 


### PR DESCRIPTION
Potential fix for [https://github.com/bxrne/launchrail/security/code-scanning/7](https://github.com/bxrne/launchrail/security/code-scanning/7)

To fix the issue, we need to validate the `hash` parameter to ensure it does not contain any path traversal sequences or invalid characters. Since the `hash` is expected to be a single-component identifier (e.g., a hash value), we can enforce this by rejecting any input that contains path separators (`/`, `\`) or parent directory references (`..`).

The validation should be implemented in the `GetRecord` method of `RecordManager` in `internal/storage/records.go`. If the validation fails, the method should return an error indicating that the input is invalid.

Additionally, we should ensure that the `hash` parameter is validated as early as possible, ideally in the `GetRecordData` handler in `cmd/server/handlers.go`, to prevent invalid input from propagating further into the application.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
