### PR TITLE
Potential fix for code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -67,8 +67,14 @@ func NewStorage(baseDir string, dir string, store StorageType) (*Storage, error)
 		return nil, err
 	}
 
-	dir = filepath.Join(baseDir, dir)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	// Clean and validate the dir parameter to prevent directory traversal
+	cleanDir := filepath.Clean(dir)
+	absDir := filepath.Join(baseDir, cleanDir)
+	if !strings.HasPrefix(absDir, baseDir) {
+		return nil, fmt.Errorf("invalid directory: %s", dir)
+	}
+
+	if err := os.MkdirAll(absDir, 0755); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/bxrne/launchrail/security/code-scanning/4](https://github.com/bxrne/launchrail/security/code-scanning/4)

To fix the issue, we need to validate the `dir` parameter before using it to construct file paths. Specifically:
1. Ensure that `dir` does not contain any path traversal sequences like `../` or absolute paths.
2. Use a safe directory resolution approach to confirm that the resulting path is within the intended `baseDir`.

The best way to implement this is to:
- Normalize the `dir` path using `filepath.Clean`.
- Check that the resulting path is still within the `baseDir` by comparing the absolute paths.

Changes will be made in the `NewStorage` function in `internal/storage/storage.go`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
