### PR TITLE
Potential fix for code scanning alert no. 5: Uncontrolled data used in path expression

### DIFF
--- a/internal/storage/records.go
+++ b/internal/storage/records.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 	"runtime"

--- a/internal/storage/records.go
+++ b/internal/storage/records.go
@@ -175,6 +175,11 @@ func (rm *RecordManager) ListRecords() ([]*Record, error) {
 
 // GetRecord retrieves an existing record by hash without creating a new one.
 func (rm *RecordManager) GetRecord(hash string) (*Record, error) {
+	// Validate the hash to ensure it is a valid directory name
+	if strings.Contains(hash, "/") || strings.Contains(hash, "\\") || strings.Contains(hash, "..") {
+		return nil, fmt.Errorf("invalid hash value")
+	}
+
 	rm.mu.RLock()
 	defer rm.mu.RUnlock()
 

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -54,6 +54,11 @@ type Stores struct {
 // NewStorage creates a new storage service.
 // If the provided baseDir is not absolute, it is prepended with the user's home directory.
 func NewStorage(baseDir string, dir string, store StorageType) (*Storage, error) {
+	// Validate the dir to ensure it is a valid directory name
+	if strings.Contains(dir, "/") || strings.Contains(dir, "\\") || strings.Contains(dir, "..") {
+		return nil, fmt.Errorf("invalid directory name")
+	}
+
 	// If baseDir is not absolute, prepend the user's home directory.
 	if !filepath.IsAbs(baseDir) {
 		homeDir, err := os.UserHomeDir()

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 )
 


### PR DESCRIPTION
Potential fix for [https://github.com/bxrne/launchrail/security/code-scanning/5](https://github.com/bxrne/launchrail/security/code-scanning/5)

To fix the issue, we need to validate the `hash` parameter to ensure it does not contain any path traversal sequences (e.g., `..`) or path separators (`/` or `\`). This can be achieved by:
1. Checking that the `hash` parameter is a valid single directory name without any special characters or sequences.
2. Rejecting the input if it fails validation.

The validation should be implemented in the `GetRecord` method of `internal/storage/records.go`, as this is where the `hash` parameter is first used to construct a file path. Additionally, the `NewStorage` function in `internal/storage/storage.go` should also validate the `dir` parameter to ensure it is safe.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
